### PR TITLE
Fix huge memory leak on uc_mem_protect()

### DIFF
--- a/uc.c
+++ b/uc.c
@@ -856,6 +856,7 @@ static bool split_region(struct uc_struct *uc, MemoryRegion *mr, uint64_t addres
             goto error;
     }
 
+    free(backup);
     return true;
 
 error:


### PR DESCRIPTION
A memory region is allocated inside split_region() that was only freed in error case but not on success case, leading to huge memory leak if the region size was significant.